### PR TITLE
Mark qwt5 as nonexistent

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -81,7 +81,7 @@ rice:
 qwt5:
     debian,ubuntu:
         default: libqwt5-qt4-dev
-        '20.04,22.04': nonexistent
+        '20.04,22.04,24.04': nonexistent
     fedora,opensuse: qwt-devel
     darwin: qwt
     arch: qwt5


### PR DESCRIPTION
Maybe it would be better to switch `default` to `nonexistent` (and very likely other OSs haven't been tested for very long, either)